### PR TITLE
Update peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "test": "yarn test:lint && yarn test:type && yarn test:unit"
   },
   "peerDependencies": {
-    "@nestjs/common": "^6.0.0",
-    "@nestjs/core": "^6.0.0",
-    "@nestjs/platform-express": "^6.0.0",
-    "@nestjs/typeorm": "^6.0.0",
+    "@nestjs/common": "^7.0.0",
+    "@nestjs/core": "^7.0.0",
+    "@nestjs/platform-express": "^7.0.0",
+    "@nestjs/typeorm": "^7.0.0",
     "typeorm": "^0.2.12"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, running `npm install nestjs-admin` on a new NestJS project fails because of incompatible peer dependencies:

```
$ npm install nestjs-admin

npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: project@0.0.1
npm ERR! Found: @nestjs/common@7.6.15
npm ERR! node_modules/@nestjs/common
npm ERR!   @nestjs/common@"^7.5.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @nestjs/common@"^6.0.0" from nestjs-admin@0.4.1
npm ERR! node_modules/nestjs-admin
npm ERR!   nestjs-admin@"*" from the root project
```